### PR TITLE
xfree86: Remove odd check definition PCI_DOM_MASK

### DIFF
--- a/hw/xfree86/os-support/bus/Pci.h
+++ b/hw/xfree86/os-support/bus/Pci.h
@@ -117,9 +117,6 @@
 #define PCI_DOM_MASK 0x0ffu
 #endif
 
-#ifndef PCI_DOM_MASK
-#define PCI_DOM_MASK 0x0ffu
-#endif
 #define PCI_DOMBUS_MASK (((PCI_DOM_MASK) << 8) | 0x0ffu)
 
 /*


### PR DESCRIPTION
PCI_DOM_MASK is already defined (see above).

Signed-off-by: Alexandr Shadchin <Alexandr.Shadchin@gmail.com>
Reviewed-by: Alan Coopersmith <alan.coopersmith@oracle.com>